### PR TITLE
fix the issue of losing the first subscription result

### DIFF
--- a/examples/ws_client_1.rb
+++ b/examples/ws_client_1.rb
@@ -1,14 +1,10 @@
 require 'scale_rb'
 
-ScaleRb.logger.level = Logger::DEBUG
+# ScaleRb.logger.level = Logger::DEBUG
 
-# the commented code below is the same as the code above
 ScaleRb::WsClient.start('wss://polkadot-rpc.dwellir.com') do |client|
   block_hash = client.chain_getBlockHash(21585684)
-  # block_hash = client.request('chain_getBlockHash', [21585684])
-
   runtime_version = client.state_getRuntimeVersion(block_hash)
-  # runtime_version = client.request('state_getRuntimeVersion', [block_hash])
-
-  puts runtime_version
+  puts runtime_version['specName']
+  puts runtime_version['specVersion']
 end

--- a/examples/ws_client_3.rb
+++ b/examples/ws_client_3.rb
@@ -13,7 +13,8 @@ ScaleRb::WsClient.start('wss://polkadot-rpc.dwellir.com') do |client|
       block_hash = client.chain_getBlockHash(block_number)
       puts "Received new head at height: #{block_number}, block hash: #{block_hash}"
     else
-      client.chain_unsubscribeNewHead(subscription_id)
+      unsub_result = client.chain_unsubscribeNewHead(subscription_id)
+      puts "Unsubscribed from new heads: #{unsub_result}"
     end
   end
 

--- a/lib/client/ws_client.rb
+++ b/lib/client/ws_client.rb
@@ -8,86 +8,6 @@ require_relative 'client_ext'
 
 module ScaleRb
   class WsClient
-    include ClientExt
-    attr_accessor :supported_methods
-
-    def initialize
-      @queue = Async::Queue.new
-      @response_handler = ResponseHandler.new
-      @subscription_handler = SubscriptionHandler.new
-      @request_id = 1
-    end
-
-    def request(method, params = [])
-      # don't check for rpc_methods, because there is no @supported_methods when initializing
-      if method != 'rpc_methods' && !@supported_methods.include?(method)
-        raise "Method `#{method}` is not supported. It should be in [#{@supported_methods.join(', ')}]."
-      end
-
-      response_future = Async::Notification.new
-
-      @response_handler.register(@request_id, proc { |response|
-        # this is running in the main task
-        response_future.signal(response['result'])
-      })
-
-      request = JsonRpcRequest.new(@request_id, method, params)
-      @queue.enqueue(request)
-
-      @request_id += 1
-
-      response_future.wait
-    end
-
-    def subscribe(method, params = [], &block)
-      return unless method.include?('subscribe')
-
-      subscription_id = request(method, params)
-      @subscription_handler.subscribe(subscription_id, block)
-      subscription_id
-    end
-
-    def unsubscribe(method, subscription_id)
-      result = request(method, [subscription_id])
-      @subscription_handler.unsubscribe(subscription_id)
-      result
-    end
-
-    def next_request
-      @queue.dequeue
-    end
-
-    def handle_response(response)
-      if response.key?('id')
-        @response_handler.handle(response)
-      elsif response.key?('method')
-        @subscription_handler.handle(response)
-      else
-        puts "Received an unknown message: #{response}"
-      end
-    end
-
-    def respond_to_missing?(*_args)
-      true
-    end
-
-    def method_missing(method, *args)
-      ScaleRb.logger.debug "#{method}(#{args.join(', ')})"
-
-      method = method.to_s
-      if method.include?('unsubscribe')
-        unsubscribe(method, args[0])
-      elsif method.include?('subscribe')
-        raise "A subscribe method needs a block" unless block_given?
-
-        subscribe(method, args) do |notification|
-          yield notification['params']['result']
-        end
-      else
-        request(method, args)
-      end
-    end
-
     def self.start(url)
       Async do |task|
         endpoint = Async::HTTP::Endpoint.parse(url, alpn_protocols: Async::HTTP::Protocol::HTTP11.names)
@@ -107,7 +27,6 @@ module ScaleRb
               data = JSON.parse(message)
               ScaleRb.logger.debug "Received message: #{data}"
 
-              # 可以简单的理解为，这里的handle_response就是通知wait中的request，可以继续了.
               Async do
                 client.handle_response(data)
               rescue => e
@@ -125,7 +44,7 @@ module ScaleRb
         end
 
         task.async do
-          client.supported_methods = client.request('rpc_methods')['methods']
+          client.supported_methods = client.rpc_methods()['methods']
           yield client
         rescue => e
           ScaleRb.logger.error "#{e.class}: #{e.message}"
@@ -133,6 +52,95 @@ module ScaleRb
           task.stop
         end
       end
+    end
+  end
+end
+
+module ScaleRb
+  class WsClient
+    include ClientExt
+    attr_accessor :supported_methods
+
+    def initialize
+      @queue = Async::Queue.new
+      @response_handler = ResponseHandler.new
+      @subscription_handler = SubscriptionHandler.new
+      @request_id = 1
+    end
+
+    def respond_to_missing?(method, *)
+      @supported_methods.include?(method.to_s)
+    end
+
+    def method_missing(method, *args)
+      method = method.to_s
+      ScaleRb.logger.debug "#{method}(#{args.join(', ')})"
+
+      # why not check 'rpc_methods', because there is no @supported_methods when initializing
+      if method != 'rpc_methods' && !@supported_methods.include?(method)
+        raise "Method `#{method}` is not supported. It should be in [#{@supported_methods.join(', ')}]."
+      end
+
+      if method.include?('unsubscribe')
+        unsubscribe(method, args[0])
+      elsif method.include?('subscribe')
+        raise "A subscribe method needs a block" unless block_given?
+
+        subscribe(method, args) do |notification|
+          yield notification['params']['result']
+        end
+      else
+        request(method, args)
+      end
+    end
+
+    def subscribe(method, params = [], &block)
+      return unless method.include?('subscribe')
+      return if method.include?('unsubscribe')
+
+      subscription_id = request(method, params)
+      @subscription_handler.subscribe(subscription_id, block)
+      subscription_id
+    end
+
+    def unsubscribe(method, subscription_id)
+      return unless method.include?('unsubscribe')
+
+      if @subscription_handler.unsubscribe(subscription_id)
+        request(method, [subscription_id])
+      end
+    end
+
+    def next_request
+      @queue.dequeue
+    end
+
+    def handle_response(response)
+      if response.key?('id')
+        @response_handler.handle(response)
+      elsif response.key?('method')
+        @subscription_handler.handle(response)
+      else
+        puts "Received an unknown message: #{response}"
+      end
+    end
+
+    private
+
+    def request(method, params = [])
+      response_future = Async::Notification.new
+
+      @response_handler.register(@request_id, proc { |response|
+        # this is running in the main task
+        response_future.signal(response['result'])
+      })
+
+      request = JsonRpcRequest.new(@request_id, method, params)
+      @queue.enqueue(request)
+
+      @request_id += 1
+
+      response_future.wait
     end
   end
 
@@ -191,10 +199,20 @@ module ScaleRb
 
     def handle(notification)
       subscription_id = notification.dig('params', 'subscription')
-      if subscription_id && @subscriptions.key?(subscription_id)
+      return if subscription_id.nil?
+
+      if @subscriptions.key?(subscription_id)
         @subscriptions[subscription_id].call(notification)
       else
-        ScaleRb.logger.debug "Received a notification with unknown subscription id: #{notification}"
+        # the subscription_id may be not registered. 
+        # in client.subscribe function, 
+        #   ...
+        #   subscription_id = request(method, params)
+        #   @subscription_handler.subscribe(subscription_id, block)
+        #   ...
+        # the request(method, params) may be slow, so the subscription_id may be not registered when the first notification comes.
+        sleep 0.01
+        handle(notification)
       end
     end
   end


### PR DESCRIPTION
For example:

```ruby
ScaleRb::WsClient.start('wss://polkadot-rpc.dwellir.com') do |client|
  client.chain_subscribeNewHead do |head|
    process(head)
  end
end
```

The first header to arrive is not processed.

This PR will solve this issue.


